### PR TITLE
Daemon-related bug fixes

### DIFF
--- a/cmd/git-bundle-server/web-server.go
+++ b/cmd/git-bundle-server/web-server.go
@@ -42,7 +42,7 @@ func (w *webServerCmd) getDaemonConfig(ctx context.Context) (*daemon.DaemonConfi
 	}
 
 	return &daemon.DaemonConfig{
-		Label:       "com.github.gitbundleserver",
+		Label:       "com.git-ecosystem.gitbundleserver",
 		Description: "Web server hosting Git Bundle Server content",
 		Program:     programPath,
 	}, nil

--- a/test/integration/features/step_definitions/daemon.ts
+++ b/test/integration/features/step_definitions/daemon.ts
@@ -26,10 +26,3 @@ Then('the daemon is not running', async function (this: IntegrationBundleServerW
   var daemonStatus = this.getDaemonState()
   assert.strictEqual(daemonStatus, DaemonState.NotRunning)
 })
-
-// After({tags: '@daemon'}, async function (this: IntegrationBundleServerWorld) {
-//   var daemonState = this.getDaemonState()
-//   if (daemonState === DaemonState.Running) {
-//     this.runCommand('git-bundle-server web-server stop')
-//   }
-// });


### PR DESCRIPTION
This series fixes oversights from #49 and #39.

The first commit updates the web server daemon with the application's new bundle id: `com.git-ecosystem.gitbundleserver`. The second commit removes an unnecessary commented step in the daemon-specific integration tests.