### PR TITLE
deb/pack.sh: fix maintainer email

### DIFF
--- a/build/package/deb/pack.sh
+++ b/build/package/deb/pack.sh
@@ -81,7 +81,7 @@ Section: vcs
 Priority: optional
 Architecture: $ARCH
 Depends:
-Maintainer: Git Bundle Server <gitfundamentals@github.com>
+Maintainer: Git Bundle Server <git-fundamentals@github.com>
 Description: A self-hostable Git bundle server.
 EOF
 


### PR DESCRIPTION
Correct the email alias used in the "Maintainer" property of the Debian package.

Reported-by: Jeff Hostetler <jeffhostetler@github.com>