### PR TITLE
Make `init` more proactive in reporting errors

### DIFF
--- a/cmd/git-bundle-server/init.go
+++ b/cmd/git-bundle-server/init.go
@@ -53,6 +53,18 @@ func (i *initCmd) Run(ctx context.Context, args []string) error {
 	bundleProvider := utils.GetDependency[bundles.BundleProvider](ctx, i.container)
 	gitHelper := utils.GetDependency[git.GitHelper](ctx, i.container)
 
+	// First, check whether route already exists (enabled or not). If it does,
+	// exit with an error.
+	allRepos, err := repoProvider.ReadRepositoryStorage(ctx)
+	if err != nil {
+		return i.logger.Errorf(ctx, "could not load existing routes: %w", err)
+	} else if _, ok := allRepos[*route]; ok {
+		return i.logger.Errorf(ctx, "route '%s' already exists; if you want to "+
+			"overwrite the route, delete it with 'git-bundle-server delete' "+
+			"then re-run this command", *route)
+	}
+
+	// Create the new route
 	repo, err := repoProvider.CreateRepository(ctx, *route)
 	if err != nil {
 		return i.logger.Error(ctx, err)

--- a/cmd/git-bundle-server/init.go
+++ b/cmd/git-bundle-server/init.go
@@ -59,7 +59,10 @@ func (i *initCmd) Run(ctx context.Context, args []string) error {
 	}
 
 	fmt.Printf("Cloning repository from %s\n", *url)
-	gitHelper.CloneBareRepo(ctx, *url, repo.RepoDir)
+	err = gitHelper.CloneBareRepo(ctx, *url, repo.RepoDir)
+	if err != nil {
+		return i.logger.Errorf(ctx, "failed to clone repository: %w", err)
+	}
 
 	bundle := bundleProvider.CreateInitialBundle(ctx, repo)
 	fmt.Printf("Constructing base bundle file at %s\n", bundle.Filename)

--- a/internal/common/filesystem.go
+++ b/internal/common/filesystem.go
@@ -215,7 +215,13 @@ func (f *fileSystem) ReadDirRecursive(path string, depth int, strictDepth bool) 
 
 	dirEntries, err := os.ReadDir(path)
 	if err != nil {
-		return nil, err
+		if errors.Is(err, os.ErrNotExist) {
+			// We tried to read the directory, but it doesn't exist - return
+			// empty result.
+			return []ReadDirEntry{}, nil
+		} else {
+			return nil, err
+		}
 	}
 
 	entries := utils.Map(dirEntries, mapDirEntry(path))


### PR DESCRIPTION
Closes #35 

This pull request fixes the remaining item in #35 (`git-bundle-server init` behaves incorrectly when the specified route already exists). The update to fix this revealed a _different_ bug affecting usage of `ReadRepositoryStorage()` (`repair` and, as of this PR, `init`) when the bundle server directory structure hasn't been created yet. 

- Commit 1 updates `init` to exit if it receives an error from `CloneBareRepo()`, rather than trying to continue with creating a base bundle (as it does now).
- Commit 2 fixes the issue with `ReadRepositoryStorage()` by ensuring `ReadDirRecursive()` catches "missing entry" errors and returns an empty result rather than an error.
- Commit 3 adds an explicit check for the specified route before `CreateRepository()`. If the route is found in the results of `ReadRepositoryStorage()`, exit with an error.